### PR TITLE
Check 'myRef' exists before accessing value

### DIFF
--- a/Fire/Business/Model/Transaction.php
+++ b/Fire/Business/Model/Transaction.php
@@ -23,7 +23,7 @@ class Transaction {
             'feeAmount' => $rawTransaction->{'feeAmount'},
             'amountAfterCharges' => $rawTransaction->{'amountAfterCharges'},
             'balance' => $rawTransaction->{'balance'},
-            'description' => $rawTransaction->{'myRef'},
+            'description' => property_exists($rawTransaction, 'myRef') ? $rawTransaction->{'myRef'} : null,
             'date' => Deserialize::iso8601DateTime($rawTransaction->{'date'})
         );
         


### PR DESCRIPTION
The reference for the transaction is optional, so check if the property exists before accessing the value. Set it to null if the property does not exist.