### PR TITLE
Check 'id' exists before accessing the value for external accounts

### DIFF
--- a/Fire/Business/Model/ExternalAccount.php
+++ b/Fire/Business/Model/ExternalAccount.php
@@ -8,7 +8,7 @@ class ExternalAccount {
     public function __construct(\stdClass $rawData) {
 
         $this->properties = array(
-            'id' => $rawData->{'id'},
+            'id' => property_exists($rawData, 'id') ? $rawData->{'id'} : null,
             'alias' => $rawData->{'alias'},
             'nsc' => @$rawData->{'nsc'},
             'accountNumber' => @$rawData->{'accountNumber'},


### PR DESCRIPTION
When receiving a lodgement webhook, the external account does not contain the 'id' property, so check if it exists before accessing the value. Set it to null if the property does not exist.